### PR TITLE
Use anchor links for section navigation

### DIFF
--- a/components/SiteLinkButton.tsx
+++ b/components/SiteLinkButton.tsx
@@ -6,25 +6,11 @@ const SiteLinkButton = (props: {
   classStyle: string;
   onClickCallback?: Function;
 }) => {
-  const scrolltoHash = function (element_id: string) {
-    const element = document.getElementById(element_id);
-    element?.scrollIntoView({
-      behavior: "smooth",
-      // block: "start",
-      // inline: "start",
-    });
-  };
-
-  const handleOnClick = (element_id: string) => {
-    scrolltoHash(element_id);
-    props.onClickCallback ? props.onClickCallback() : null;
-  };
-
   return (
     <Link
       className={props.classStyle}
-      href="#"
-      onClick={() => handleOnClick(props.sectionId)}
+      href={`#${props.sectionId}`}
+      onClick={() => (props.onClickCallback ? props.onClickCallback() : null)}
       type="button"
     >
       {props.children}

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -2,6 +2,10 @@
 @tailwind components;
 @tailwind utilities;
 
+html {
+  scroll-behavior: smooth;
+}
+
 body {
   overflow: visible;
 }


### PR DESCRIPTION
## Summary
- simplify site link button to use native anchor hash navigation
- enable smooth scrolling via CSS

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68929ae00bdc8323a6952a6668b2bea2