### PR TITLE
feat: improve image loading with sizes and blur placeholders

### DIFF
--- a/components/ImageCarousel.tsx
+++ b/components/ImageCarousel.tsx
@@ -11,6 +11,9 @@ import { imageReference } from "@/lib/images";
 import { useAppSelector, useAppDispatch } from "@/hooks/reduxHooks";
 import { IPopupType, addPopup } from "@/features/popup/popupSlice";
 
+const blurDataURL =
+  "data:image/svg+xml;base64,PHN2ZyB4bWxucz0naHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmcnIHdpZHRoPScxJyBoZWlnaHQ9JzEnPjxyZWN0IHdpZHRoPScxJyBoZWlnaHQ9JzEnIGZpbGw9JyNjY2MnLz48L3N2Zz4=";
+
 const ImageCarousel = (props: { images: Array<imageReference> }) => {
   const { images } = props;
   const dispatch = useAppDispatch();
@@ -121,6 +124,9 @@ const ImageCarousel = (props: { images: Array<imageReference> }) => {
                 src={image.src}
                 fill={true}
                 alt={image.name}
+                placeholder="blur"
+                blurDataURL={blurDataURL}
+                sizes="(max-width: 640px) 240px, 320px"
                 style={{ objectFit: "cover" }}
               />
             </motion.button>

--- a/components/Slideshow.tsx
+++ b/components/Slideshow.tsx
@@ -13,6 +13,9 @@ import ReactPlayer from "react-player/lazy";
 //redux
 import { useAppSelector } from "@/hooks/reduxHooks";
 
+const blurDataURL =
+  "data:image/svg+xml;base64,PHN2ZyB4bWxucz0naHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmcnIHdpZHRoPScxJyBoZWlnaHQ9JzEnPjxyZWN0IHdpZHRoPScxJyBoZWlnaHQ9JzEnIGZpbGw9JyNjY2MnLz48L3N2Zz4=";
+
 type slideshowProps = {
   currentIndex: number;
   imageRefs: imageReference[];
@@ -129,6 +132,9 @@ const Slideshow = (props: slideshowProps) => {
                   src={image.src}
                   fill={true}
                   alt={image.name}
+                  placeholder="blur"
+                  blurDataURL={blurDataURL}
+                  sizes="100vw"
                   className="object-contain w-full h-full mx-auto"
                 />
               </motion.div>


### PR DESCRIPTION
## Summary
- add low-quality blur placeholders for slideshow and carousel images
- define responsive `sizes` for `next/image` to optimize loading

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68929b16ed4c832393726d73d915ca9b